### PR TITLE
Add files via upload

### DIFF
--- a/01.automorphic.rkt
+++ b/01.automorphic.rkt
@@ -1,0 +1,33 @@
+#lang racket
+(require rackunit rackunit/text-ui)
+
+;### Зад 1
+; Дали `x` е автоморфно?
+; Едно число е автоморфно, ако квадратът му завършва на него.
+(define (automorphic? x)
+  (define (helper x x^2)
+   (if (= x 0) #t (if (= (remainder x^2 10) (remainder x 10)) (helper (quotient x 10) (quotient x^2 10)) #f))
+    )
+  (helper x (* x x))
+  )
+
+(run-tests
+  (test-suite
+    "automorphic? tests"
+    (check-false (automorphic? 2))
+    (check-false (automorphic? 3))
+    (check-false (automorphic? 4))
+    (check-false (automorphic? 7))
+    (check-false (automorphic? 8))
+    (check-false (automorphic? 9))
+    (check-false (automorphic? 10))
+
+    (check-true (automorphic? 1))
+    (check-true (automorphic? 5))
+    (check-true (automorphic? 6))
+    (check-true (automorphic? 25))
+    (check-true (automorphic? 76))
+    (check-true (automorphic? 376))
+    (check-true (automorphic? 625))
+    (check-true (automorphic? 9376)))
+  'verbose)

--- a/02.count-pairs-gcd.rkt
+++ b/02.count-pairs-gcd.rkt
@@ -1,0 +1,43 @@
+#lang racket
+(require rackunit rackunit/text-ui)
+
+;### Зад 2
+; Броят на наредените двойки цели числа от интервала [`a`,`b`],
+; които имат най-голям общ делител равен на `n`.
+(define (count-pairs-gcd n a b)
+  
+  (define (helper n start end i j res)
+    (cond ((> i end) res)
+          ((> j end) (helper n start end (+ i 1) start res))
+          ((= n (gcd i j)) (helper n start end i (+ j 1) (+ res 1)))
+          (else (helper n start end i (+ j 1) res))
+          )
+    )
+  
+  (helper n a b a a 0)
+  
+)
+
+(define (abs x)
+  (if (< x 0) (* -1 x) x)
+  )
+
+(define (gcd a b)
+  (gcd-abs (abs a) (abs b))
+  )
+
+(define (gcd-abs a b)
+  (if (= a b) a (if (> a b) (gcd-abs (- a b) b) (gcd-abs a (- b a))))
+  )
+
+(run-tests
+  (test-suite "count-pairs-gcd tests"
+    (check-eq? (count-pairs-gcd 10 1 11)
+               1)
+    (check-eq? (count-pairs-gcd 3 1 11)
+               7)
+    (check-eq? (count-pairs-gcd 16 1 11)
+               0)
+    (check-eq? (count-pairs-gcd 4 1 11)
+               3))
+  'verbose)

--- a/03.min-duplicate.rkt
+++ b/03.min-duplicate.rkt
@@ -1,0 +1,28 @@
+#lang racket
+(require rackunit rackunit/text-ui)
+
+;### Зад 3
+; Намира най-малкото число, което се среща поне 2 пъти в списъка `l`.
+(define (min-duplicate l)
+  (define (helper l result found)
+   (if (null? l) result (if (duplicate-in (car l) (cdr l)) (if found (if (< (car l) result) (helper (cdr l) (car l) #t) (helper (cdr l) result #t)) (helper (cdr l) (car l) #t)) (helper (cdr l) result found)))
+    )
+  (helper l 0 #f)
+   )
+
+(define (duplicate-in x list)
+ (if (null? list) #f (if (eqv? x (car list)) #t (duplicate-in x (cdr list))))
+  )
+
+
+(run-tests
+  (test-suite "min-duplicate tests"
+    (check-eq? (min-duplicate '(-8 -8))
+               -8)
+    (check-eq? (min-duplicate '(1 2 3 4 4 5 6))
+               4)
+    (check-eq? (min-duplicate '(5 1 2 3 4 5 3 6 2 3 2 3 2 3))
+               2)
+    (check-eq? (min-duplicate '(3 2 2 2 1 1))
+               1))
+  'verbose)

--- a/04.sudoku.rkt
+++ b/04.sudoku.rkt
@@ -1,0 +1,246 @@
+#lang racket
+(require rackunit rackunit/text-ui)
+
+;### Зад 4
+; Дали полето `board` изпълнява правилата на судоку - всеки ред, колона и
+; всяко 3x3 подполе да съдържа точно всички елементи от `alphabet`.
+
+(define (sudoku-solved? alphabet board)
+  (if (and (good-every-row alphabet board) (good-every-col alphabet board) (good-every-block alphabet board)) #t #f)
+ )
+
+
+(define (good-every-col alphabet matrix)
+   (define (helper alphabet index-of-col matrix)
+      (cond
+        ((= index-of-col 9) #t)
+        ((not (good-line alphabet (take-i-col index-of-col matrix))) #f)
+        (else (helper alphabet (+ 1 index-of-col) matrix))
+        )
+     )
+  (helper alphabet 0 matrix)
+  )
+
+(define (take-i-col i matrix)
+  (define (helper i matrix res)
+    (cond
+      ((null? matrix) res)
+      (else (helper i (cdr matrix) (append res (cons (take-i-el-in-line i (car matrix)) '()))))
+      )
+  )
+  (helper i matrix '())
+)
+
+(define (take-i-row i matrix)
+  (cond
+    ((= i 0) (car matrix))
+    (else (take-i-row (- i 1) (cdr matrix)))
+    )
+ )
+
+(define (take3elements-from-line-startindex start  line)
+  (cond
+    ((= start 0) (list (car line) (car (cdr line)) (car (cddr line))))
+    (else (take3elements-from-line-startindex (- start 3) (cdddr line)))
+    )
+)
+
+(define (take-i-el-in-line i line)
+  (cond
+    ((= i 0) (car line))
+    (else (take-i-el-in-line (- i 1) (cdr line)))
+    )
+  )
+
+(define (good-every-row alphabet matrix)
+  (cond
+    ((null? matrix) #t)
+    ((not (good-line alphabet (car matrix))) #f)
+    (else (good-every-row alphabet (cdr matrix)))
+    )
+  )
+
+(define (good-line alphabet line)
+ (define (all-elements-in-alphabet alphabet list)
+  (cond
+    ((null? alphabet) #t)
+    ((null? list) #t)
+    ((not (= 1 (count-of-symbol-in-list (car alphabet) list))) #f)
+    (else (all-elements-in-alphabet (cdr alphabet) list))
+   )
+  )
+  (all-elements-in-alphabet alphabet line)
+)
+
+(define (count-of-symbol-in-list symbol list)
+  (define (helper symbol list res)
+    (if (null? list) res (if (eqv? symbol (car list)) (helper symbol (cdr list) (+ res 1)) (helper symbol (cdr list) res) ))
+    )
+  (helper symbol list 0)
+ )
+
+(define (take-i-3x3-block i matrix)                            ; 0<=i<=8      0     1     2
+                                                               ;              3     4     5
+                                                               ;              6     7     8
+     
+      (cond
+       ((or (= i 0) (= i 3) (= i 6)) (append (take3elements-from-line-startindex 0 (take-i-row i matrix))
+                                             (take3elements-from-line-startindex 0 (take-i-row (+ i 1) matrix))
+                                             (take3elements-from-line-startindex 0 (take-i-row (+ i 2) matrix))))
+        ((or (= i 1) (= i 4) (= i 7)) (append (take3elements-from-line-startindex 3 (take-i-row (- i 1) matrix))
+                                             (take3elements-from-line-startindex 3 (take-i-row  i  matrix))
+                                             (take3elements-from-line-startindex 3 (take-i-row (+ i 1) matrix))))
+        (else (append (take3elements-from-line-startindex 6 (take-i-row (- i 2) matrix))
+                                             (take3elements-from-line-startindex 6 (take-i-row  (- i 1)  matrix))
+                                             (take3elements-from-line-startindex 6 (take-i-row i matrix))))
+         ) 
+ )
+
+(define (good-every-block alphabet matrix)
+  (define (helper index-of-block alphabet matrix)
+    (cond
+      ((= index-of-block 9) #t)
+      ((not (good-line alphabet (take-i-3x3-block index-of-block matrix))) #f)
+      (else (helper (+ index-of-block 1) alphabet matrix)))
+      )
+    
+  (helper 0 alphabet matrix)
+  )
+                                                           
+(define (reverse-list list)
+     (if (null? list) '() (append (reverse-list (cdr list)) (cons (car list) '())))
+  )
+
+(define board1
+  '((5 3 4  6 7 8  9 1 2)
+    (6 7 2  1 9 5  3 4 8)
+    (1 9 8  3 4 2  5 6 7)
+
+    (8 5 9  7 6 1  4 2 3)
+    (4 2 6  8 5 3  7 9 1)
+    (7 1 3  9 2 4  8 5 6)
+
+    (9 6 1  5 3 7  2 8 4)
+    (2 8 7  4 1 9  6 3 5)
+    (3 4 5  2 8 6  1 7 9)))
+
+(define board2
+  '((3 8 7  4 1 6  5 2 9)
+    (6 4 5  9 2 7  8 3 1)
+    (2 1 9  3 8 5  7 4 6)
+
+    (9 2 4  1 6 8  3 7 5)
+    (7 3 1  5 4 2  6 9 8)
+    (8 5 6  7 3 9  4 1 2)
+
+    (5 7 3  6 9 1  2 8 4)
+    (1 6 8  2 7 4  9 5 3)
+    (4 9 2  8 5 3  1 6 7)))
+
+(define board1-grid
+  '((5 3 4  6 7 8 9 1 2)
+    (6 7 5  1 9 2 3 4 8)
+    (1 9 8  3 4 2 5 6 7)
+
+    (8 5 9  7 6 1 4 2 3)
+    (4 2 6  8 5 3 7 9 1)
+    (7 1 3  9 2 4 8 5 6)
+    (9 6 1  5 3 7 2 8 4)
+    (2 8 7  4 1 9 6 3 5)
+    (3 4 5  2 8 6 1 7 9)))
+(define board1-row
+  '((5 3 4 5 7 8 9 1 2)
+    (6 7 2 1 9 5 3 4 8)
+    (1 9 8 3 4 2 5 6 7)
+    (8 5 9 7 6 1 4 2 3)
+    (4 2 6 8 5 3 7 9 1)
+    (7 1 3 9 2 4 8 5 6)
+    (9 6 1 5 3 7 2 8 4)
+    (2 8 7 4 1 9 6 3 5)
+    (3 4 5 2 8 6 1 7 9)))
+(define board1-col
+  '((5 3 4 6 7 8 9 1 2)
+    (6 7 2 1 9 5 3 4 8)
+    (1 9 8 3 4 2 5 6 7)
+    (8 5 9 7 6 1 4 2 3)
+    (4 2 6 8 5 3 7 9 1)
+    (7 1 3 9 2 4 8 5 6)
+    (9 6 1 5 3 7 5 8 4)
+    (2 8 7 4 1 9 6 3 5)
+    (3 4 5 2 8 6 1 7 9)))
+(define board2-false
+  '((3 8 7  4 1 6  5 2 9)
+    (6 4 5  9 2 7  8 3 1)
+    (2 1 9  3 8 5  7 4 6)
+
+    (9 2 4  1 6 8  3 7 5)
+    (7 3 1  #f 4 2  6 9 8)
+    (8 5 6  7 3 9  4 1 2)
+
+    (5 7 3  6 9 1  2 8 4)
+    (1 6 8  2 7 4  9 5 3)
+    (4 9 2  8 5 3  1 6 7)))
+
+(define board1-roman
+  '((V III IV  VI VII VIII  IX I II)
+    (VI VII II  I IX V  III IV VIII)
+    (I IX VIII  III IV II  V VI VII)
+
+    (VIII V IX  VII VI I  IV II III)
+    (IV II VI  VIII V III  VII IX I)
+    (VII I III  IX II IV  VIII V VI)
+
+    (IX VI I  V III VII  II VIII IV)
+    (II VIII VII  IV I IX  VI III V)
+    (III IV V  II VIII VI  I VII IX)))
+
+(define board3-letters
+  '((w p e  k a r  i b d)
+    (d i a  b w p  k e r)
+    (r b k  e i d  p a w)
+
+    (p e r  i k w  a d b)
+    (i w b  d p a  r k e)
+    (k a d  r b e  w p i)
+
+    (b k w  a e i  d r p)
+    (a d p  w r b  e i k)
+    (e r i  p d k  b w a)))
+(define board3-dup
+  '((w p e  k a r  i b d)
+    (d i a  b w p  k e r)
+    (r b k  e i d  p a w)
+
+    (p e r  i w w  a d b)
+    (i w b  d p a  r k e)
+    (k a d  r b e  w p i)
+
+    (b k w  a e i  d r p)
+    (a d p  w r b  e i k)
+    (e r i  p d k  b w a)))
+
+(define digits '(1 2 3 4 5 6 7 8 9))
+(define digits-perm '(7 5 3 9 8 1 2 6 4))
+(define roman-numbers '(I II III IV V VI VII VIII IX))
+(define letters '(a b d e i k p r w))
+
+(run-tests
+  (test-suite "sudoku-solved? tests"
+    (check-true (sudoku-solved? digits board1))
+    (check-true (sudoku-solved? digits board2))
+    (check-false (sudoku-solved? digits board1-grid))
+    (check-false (sudoku-solved? digits board1-row))
+    (check-false (sudoku-solved? digits board1-col))
+    (check-false (sudoku-solved? digits board2-false))
+
+    (check-true (sudoku-solved? digits-perm board1))
+    (check-true (sudoku-solved? digits-perm board2))
+    (check-false (sudoku-solved? digits-perm board1-grid))
+    (check-false (sudoku-solved? digits-perm board1-row))
+    (check-false (sudoku-solved? digits-perm board1-col))
+    (check-false (sudoku-solved? digits-perm board2-false))
+
+    (check-true (sudoku-solved? roman-numbers board1-roman))
+    (check-true (sudoku-solved? letters board3-letters))
+    (check-false (sudoku-solved? letters board3-dup)))
+  'verbose)


### PR DESCRIPTION
# Първо домашно по ФП

**Срок:** 26 ноември, 17:00

> В текущата директория има по един файл с unit тестове за всяка задача. Решенията си пишете в тези файлове и ги предавате в zip архив в мудъл.
#### [Сваляне на файловете](https://download-directory.github.io/?url=https%3A%2F%2Fgithub.com%2Ftriffon%2Ffp-2021-22%2Ftree%2Fmaster%2Fhomeworks%2F1-scheme)

> Unit тестовете са за улеснение при решаване на задачите. Те не са изчерпателни. При оценяването се гледа вашият код и дали отговаря на условието.

### [Зад 1][p1] (2т.)
Функция `automorphic?`, която намира дали дадено число е автоморфно,
тоест дали квадратът му завършва на него.

```scheme
(automorphic? 6) -> #t  ; 6^2  = 36
(automorphic? 5) -> #t  ; 5^2  = 25

(automorphic? 4) -> #f  ; 4^2  = 16
(automorphic? 11) -> #f ; 11^2 = 121
```

### [Зад 2][p2] (4т.)
Функция `count-pairs-gcd`, която намира броят на наредените двойки от цели числа
от интервала [a,b], които имат най-голям общ делител равен на `n`.

### [Зад 3][p3] (4т.)
Функция `min-duplicate`, която по списък от числа намира най-малкото число,
което се среща поне 2 пъти в списъка.

```scheme
(min-duplicate '(1 2 3 8 3 3 6 6 8 4)) -> 3
```

### [Зад 4][p4] (5т.)
Функция `sudoku-solved?`, която приема списък от атоми `alphabet` и поле с размер 9x9 `board`.
Функцията намира дали полето изпълнява правилата на судоку - всеки ред, колона и
всяко 3x3 подполе да съдържа точно всички елементи от `alphabet`.

Ако `alphabet` е `'(1 2 3 4 5 6 7 8 9)` (вкл. и друга пермутация на този списък),
то говорим за стандартните правила на судоку, в които редовете, колоните и
подполетата съдържат цифрите от 1 до 9 без повторение.

Други примери за `alphabet` са `'(a b d e i k p r w)` и `'(I II III IV V VI VII VIII IX)`,
като тогава играта се нарича съответно "Wordoku" и "Quadratum latinum".

Подполетата са 9 на брой, имат размер 3x3, образуват разбиване на полето (тоест не се припокриват и
обединението им е цялото поле) и винаги започват в ред и колона кратни на 3.
На следната картинка удебелените линии очертават подполетата:

![](sudoku.svg)

Полето се подава като втори аргумент на `sudoku-solved?` във вид на списък от редове.
За горната картинка, полето се представя като:

```scheme
(define example-board1
  '((5 3 4  6 7 8  9 1 2)
    (6 7 2  1 9 5  3 4 8)
    (1 9 8  3 4 2  5 6 7)

    (8 5 9  7 6 1  4 2 3)
    (4 2 6  8 5 3  7 9 1)
    (7 1 3  9 2 4  8 5 6)

    (9 6 1  5 3 7  2 8 4)
    (2 8 7  4 1 9  6 3 5)
    (3 4 5  2 8 6  1 7 9)))
```
Очаква се `(sudoku-solved? '(1 2 3 4 5 6 7 8 9) example-board1)` да върне `#t`.

А за неправилно поле, например:
```scheme
(define example-board2
  '((5 3 4  6 7 8  9 1 2)
    (6 5 2  1 9 7  3 4 8)
    (1 9 8  3 4 2  5 6 7)

    (8 5 9  7 6 1  4 2 3)
    (4 2 6  8 5 3  7 9 1)
    (7 1 3  9 2 4  8 5 6)

    (9 6 1  5 3 7  2 8 4)
    (2 8 7  4 1 9  6 3 5)
    (3 4 5  2 8 6  1 7 9)))
```
се очаква `(sudoku-solved? '(1 2 3 4 5 6 7 8 9) example-board2)` да върне `#f`,
тъй като в първото подполе се среща два пъти `5`.


[p1]: ./01.automorphic.rkt
[p2]: ./02.count-pairs-gcd.rkt
[p3]: ./03.min-duplicate.rkt
[p4]: ./04.sudoku.rkt